### PR TITLE
Use the defaultTTL when defaultTTL is set to undefined

### DIFF
--- a/lib/ceych.js
+++ b/lib/ceych.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const Catbox = require('catbox').Client;
 const Memory = require('catbox-memory');
 const memoize = require('./memoize');
@@ -16,12 +17,12 @@ function validateClientOpts(opts) {
     opts.cacheClient = new Catbox(new Memory());
   }
 
-  if (!opts.hasOwnProperty('defaultTTL')) {
-    opts.defaultTTL = 30;
+  if (!_.isUndefined(opts.defaultTTL) && opts.defaultTTL <= 0) {
+    throw new Error('Default TTL cannot be less than or equal to zero');
   }
 
-  if (opts.defaultTTL <= 0) {
-    throw new Error('Default TTL cannot be less than or equal to zero');
+  if (!opts.defaultTTL) {
+    opts.defaultTTL = 30;
   }
 
   return opts;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,14 @@
   "engines": {
     "node": ">=4.0.0"
   },
+  "keywords": [
+    "ceych",
+    "cache",
+    "wrapper",
+    "memoize",
+    "client",
+    "stats"
+  ],
   "dependencies": {
     "catbox": "^7.1.0",
     "catbox-memory": "^2.0.1",

--- a/test/lib/ceych.js
+++ b/test/lib/ceych.js
@@ -50,6 +50,13 @@ describe('ceych', () => {
       assert.strictEqual(ceych.defaultTTL, 30);
     });
 
+    it('uses the default TTL when defaultTTL is undefined', () => {
+      const ceych = new Ceych({
+        defaultTTL: undefined
+      });
+      assert.strictEqual(ceych.defaultTTL, 30);
+    });
+
     it('throws an error when the default TTL < 0', () => {
       assert.throws(() => {
         new Ceych({


### PR DESCRIPTION
If I specify some options, and `defaultTTL` is set, but as `undefined`

```js
const opts = {
  "defaultTTL": undefined,
  "cacheClient": new Catbox(new Memory())
}

const ceych = new Ceych(opts);
```

Then the default TTL is not used.

Also added some keywords.