### PR TITLE
No error if cache connection fails

### DIFF
--- a/lib/ceych.js
+++ b/lib/ceych.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const Catbox = require('catbox').Client;
 const Memory = require('catbox-memory');
 const memoize = require('./memoize');
@@ -60,9 +61,7 @@ function getWrapOpts(defaultTTL, args) {
 function Ceych(opts) {
   opts = validateClientOpts(opts);
 
-  opts.cacheClient.start((err) => {
-    if (err) throw new Error(`Failed to initialize cache client: ${err.message}`);
-  });
+  opts.cacheClient.start(_.noop);
 
   this.defaultTTL = opts.defaultTTL;
   this.cache = opts.cacheClient;

--- a/test/lib/ceych.js
+++ b/test/lib/ceych.js
@@ -28,14 +28,12 @@ describe('ceych', () => {
     sandbox.restore();
   });
 
-  it('throws an error if starting the cache client fails', () => {
+  it('does not error if cache client fails', () => {
     sandbox.stub(cacheClient, 'start').yields(new Error('DB connection failure'));
 
-    assert.throws(() => {
-      new Ceych({
-        cacheClient: cacheClient
-      });
-    }, Error, 'Failed to initialize cache client: DB connection failure');
+    new Ceych({
+      cacheClient: cacheClient
+    });
   });
 
   describe('validation', () => {


### PR DESCRIPTION
The cache in our application is meant to be an enhancement rather than a dependency of our app and so it would be preferable if the error handler did not re-throw the cache client error. At the moment, if you attempt to start our application without having a cache cluster available it just fails to start. Also, because this error happens in the next tick of the process there's also no easy way of catching this error and handling it within the application.

This matches the behaviour of flashheart:
https://github.com/bbc/flashheart/blob/master/index.js#L10