### PR TITLE
Add support for promises

### DIFF
--- a/lib/ceych.js
+++ b/lib/ceych.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const Catbox = require('catbox').Client;
 const Memory = require('catbox-memory');
 const memoize = require('./memoize');
+const noop = () => { };
 
 function validateClientOpts(opts) {
   if (!opts) {
@@ -33,11 +34,11 @@ function getWrapOpts(defaultTTL, args) {
   let suffix = '';
 
   if (!args.length) {
-    throw new Error('Can only wrap a function, received nothing');
+    throw new Error('Can only wrap a function or a promise, received nothing');
   }
 
-  if (typeof args[0] !== 'function') {
-    throw new Error(`Can only wrap a function, received [${args[0]}]`);
+  if (typeof args[0] !== 'function' && typeof args[0].then !== 'function') {
+    throw new Error(`Can only wrap a function or a promise, received [${args[0]}]`);
   }
 
   if (args[1] && typeof args[1] === 'number') {
@@ -58,6 +59,25 @@ function getWrapOpts(defaultTTL, args) {
   };
 }
 
+function callbackify(promise) {
+  return (cb) => {
+    promise
+      .then((data) => {
+        setImmediate(cb, null, data);
+      })
+      .catch((err) => {
+        setImmediate(cb, err);
+      });
+  };
+}
+
+function squashArguments(args) {
+  if (args.length > 1) {
+    return args;
+  }
+  return args[0];
+}
+
 function Ceych(opts) {
   opts = validateClientOpts(opts);
 
@@ -72,14 +92,35 @@ Ceych.prototype.wrap = function wrap(func, ttl, suffix) { // eslint-disable-line
   const args = Array.prototype.slice.call(arguments);
   const opts = getWrapOpts(this.defaultTTL, args);
 
+  if (Promise.resolve(func) === func) {
+    func = callbackify(func);
+  }
+
   if (this.stats) {
     opts.statsClient = this.stats;
   }
 
-  return memoize(this.cache, opts, func);
+  const wrappedFn = memoize(this.cache, opts, func);
+  return (callback = noop) => {
+    return new Promise((resolve, reject) => {
+      wrappedFn(function () {
+        const err = arguments[0];
+        if (err) {
+          callback(err);
+          return reject(err);
+        }
+
+        callback.apply(this, arguments);
+
+        const remainingArguments = Array.prototype.slice.call(arguments, 1);
+
+        return resolve(squashArguments(remainingArguments));
+      });
+    });
+  };
 };
 
-Ceych.prototype.disableCache = function() {
+Ceych.prototype.disableCache = function () {
   this.cache.stop();
 };
 

--- a/lib/ceych.js
+++ b/lib/ceych.js
@@ -103,8 +103,7 @@ Ceych.prototype.wrap = function wrap(func, ttl, suffix) { // eslint-disable-line
   const wrappedFn = memoize(this.cache, opts, func);
   return (callback = noop) => {
     return new Promise((resolve, reject) => {
-      wrappedFn(function () {
-        const err = arguments[0];
+      wrappedFn(function (err) {
         if (err) {
           callback(err);
           return reject(err);


### PR DESCRIPTION
**Permit me kind sirs to put to you a request of code merge to allow your fine ceyching library to support promises.**

This addition should allow the following syntax:

```js
const ceychedDatum = ceych.wrap(getBigDatum);

ceychedDatum()
  .then((datum) => {
    processBigDatum(datum);
  })
  .catch((datumErr) => { /* handle err */ }
```

Or even:

```js
const ceychedDatum = ceych.wrap(getBigDatum);

try {
  const datum = await ceychedDatum();
  processBigDatum(datum);
} catch (datumErr) { /* handle err */ }
```

I've tried to limit the changes to just the Ceych module. The rest of the code still works with traditional callback functions. I also tried to ensure backwards compatibility was maintained - but there was a lack of end to end testing (via the Ceych module) so I may have missed some edge cases.

I look forward to your kind words.