### PR TITLE
Add support for promises

### DIFF
--- a/lib/ceych.js
+++ b/lib/ceych.js
@@ -33,11 +33,11 @@ function getWrapOpts(defaultTTL, args) {
   let suffix = '';
 
   if (!args.length) {
-    throw new Error('Can only wrap a function, received nothing');
+    throw new Error('Can only wrap a function or a promise, received nothing');
   }
 
-  if (typeof args[0] !== 'function') {
-    throw new Error(`Can only wrap a function, received [${args[0]}]`);
+  if (typeof args[0] !== 'function' && typeof args[0].then !== 'function') {
+    throw new Error(`Can only wrap a function or a promise, received [${args[0]}]`);
   }
 
   if (args[1] && typeof args[1] === 'number') {
@@ -58,6 +58,25 @@ function getWrapOpts(defaultTTL, args) {
   };
 }
 
+function callbackify(promise) {
+  return (cb) => {
+    promise
+      .then((data) => {
+        setImmediate(cb, null, data);
+      })
+      .catch((err) => {
+        setImmediate(cb, err);
+      });
+  };
+}
+
+function squashArguments(args) {
+  if (args.length > 1) {
+    return args;
+  }
+  return args[0];
+}
+
 function Ceych(opts) {
   opts = validateClientOpts(opts);
 
@@ -72,14 +91,50 @@ Ceych.prototype.wrap = function wrap(func, ttl, suffix) { // eslint-disable-line
   const args = Array.prototype.slice.call(arguments);
   const opts = getWrapOpts(this.defaultTTL, args);
 
+  if (Promise.resolve(func) === func) {
+    func = callbackify(func);
+  }
+
   if (this.stats) {
     opts.statsClient = this.stats;
   }
 
-  return memoize(this.cache, opts, func);
+  const wrappedFn = memoize(this.cache, opts, func);
+
+  return function () {
+    const args = Array.prototype.slice.call(arguments, 0);
+    let callback;
+
+    if (typeof args[args.length - 1] === 'function') {
+      callback = args.pop();
+    } else {
+      callback = () => { };
+    }
+
+    const handleResponse = function (err) {
+      if (err) {
+        callback(err);
+        return this.reject(err);
+      }
+
+      callback.apply(this, arguments);
+
+      const remainingArguments = Array.prototype.slice.call(arguments, 1);
+      return this.resolve(squashArguments(remainingArguments));
+    };
+
+    return new Promise(function (resolve, reject) {
+      const scope = {
+        resolve: resolve,
+        reject: reject
+      };
+      args.push(handleResponse.bind(scope));
+      wrappedFn.apply(this, args);
+    });
+  };
 };
 
-Ceych.prototype.disableCache = function() {
+Ceych.prototype.disableCache = function () {
   this.cache.stop();
 };
 

--- a/test/lib/ceych.js
+++ b/test/lib/ceych.js
@@ -70,13 +70,13 @@ describe('ceych', () => {
       it('must have at least 1 argument', () => {
         assert.throw(() => {
           ceych.wrap();
-        }, Error, 'Can only wrap a function, received nothing');
+        }, Error, 'Can only wrap a function or a promise, received nothing');
       });
 
       it('only takes a function as the first argument', () => {
         assert.throw(() => {
           ceych.wrap(1);
-        }, Error, 'Can only wrap a function, received [1]');
+        }, Error, 'Can only wrap a function or a promise, received [1]');
       });
 
       it('sets the TTL if the second argument is an integer', (done) => {
@@ -137,6 +137,107 @@ describe('ceych', () => {
         });
       });
     });
+
+    it('passes the parameters to the wrapped function', (done) => {
+      const myFun = (one, two, three, cb) => {
+        cb(null, one + two + three);
+      };
+      const wrappedFn = ceych.wrap(myFun);
+
+      wrappedFn(1, 2, 3, (err, results) => {
+        assert.ifError(err);
+        assert.strictEqual(results, 6);
+
+        done();
+      });
+    });
+
+    describe('Callbacks', () => {
+      it('returns a function that accepts a callback', (done) => {
+        const wrappableStub = sandbox.stub().yields(null, 1, 2, 3);
+        const func = ceych.wrap(wrappableStub);
+
+        func((err, one, two, three) => {
+          assert.ifError(err);
+          assert.strictEqual(one, 1);
+          assert.strictEqual(two, 2);
+          assert.strictEqual(three, 3);
+          done();
+        });
+      });
+
+      it('it returns an error object as the first parameter to the callback', (done) => {
+        const expectedError = new Error('You never called me back');
+        const wrappableStub = sandbox.stub().yields(expectedError);
+        const func = ceych.wrap(wrappableStub);
+
+        func((err) => {
+          assert.deepEqual(err, err);
+          done();
+        }).catch(() => {
+
+        });
+      });
+    });
+
+    describe('Promises', () => {
+      it('returns a promisified function', () => {
+        const wrappableStub = sandbox.stub().yields(null, 1, 2, 3);
+        const func = ceych.wrap(wrappableStub);
+
+        return func()
+          .then((results) => {
+            assert.deepEqual(results, [1, 2, 3]);
+          }).catch((err) => {
+            assert.ifError(err);
+          });
+      });
+
+      it('accepts a promisified function to wrap', () => {
+        const wrappableStub = new Promise((resolve) => {
+          resolve([1, 2, 3]);
+        });
+
+        const func = ceych.wrap(wrappableStub);
+
+        return func()
+          .then((results) => {
+            assert.deepEqual(results, [1, 2, 3]);
+          }).catch((err) => {
+            assert.ifError(err);
+          });
+      });
+
+      it('handles errors from callback functions correctly', () => {
+        const expectedErr = new Error('Broken promises');
+        const wrappableStub = sandbox.stub().yields(expectedErr);
+        const func = ceych.wrap(wrappableStub);
+
+        return func()
+          .then(() => {
+            throw new Error('Promise should not have been resolved');
+          }).catch((err) => {
+            assert.deepEqual(err, expectedErr);
+          });
+      });
+
+      it('handles errors from promises correctly', () => {
+        const expectedError = new Error('Broken promises');
+        const wrappableStub = new Promise((resolve, reject) => {
+          reject(expectedError);
+        });
+
+        const func = ceych.wrap(wrappableStub);
+
+        return func()
+          .then(() => {
+            throw new Error('Promise should not have been resolved');
+          }).catch((err) => {
+            assert.deepEqual(err, expectedError);
+          });
+      });
+    });
+
   });
 
   describe('.disableCache', () => {


### PR DESCRIPTION
**Permit me kind sirs to put to you a request of code merge to allow your fine ceyching library to support promises.**

This addition should allow the following syntax:

```js
const ceychedDatum = ceych.wrap(getBigDatum);

ceychedDatum()
  .then((datum) => {
    processBigDatum(datum);
  })
  .catch((datumErr) => { /* handle err */ }
```

Or even:

```js
const ceychedDatum = ceych.wrap(getBigDatum);

try {
  const datum = await ceychedDatum();
  processBigDatum(datum);
} catch (datumErr) { /* handle err */ }
```

I've tried to limit the changes to just the Ceych module. The rest of the code still works with traditional callback functions. I also tried to ensure backwards compatibility was maintained - but there was a lack of end to end testing (via the Ceych module) so I may have missed some edge cases.

I look forward to your kind words.