### PR TITLE
Promises

### DIFF
--- a/lib/ceych.js
+++ b/lib/ceych.js
@@ -6,20 +6,20 @@ const Memory = require('catbox-memory');
 const memoize = require('./memoize');
 const Promise = require('bluebird');
 
-function buildDefaultCacheClient() {
-  return Promise.promisifyAll(new Catbox(new Memory()));
+function createDefaultCacheClient() {
+  return new Catbox(new Memory());
 }
 
 function validateClientOpts(opts) {
   if (!opts) {
     opts = {
-      cacheClient: buildDefaultCacheClient(),
+      cacheClient: createDefaultCacheClient(),
       defaultTTL: 30
     };
   }
 
   if (!opts.cacheClient) {
-    opts.cacheClient = buildDefaultCacheClient();
+    opts.cacheClient = createDefaultCacheClient();
   }
 
   if (!opts.hasOwnProperty('defaultTTL')) {
@@ -30,6 +30,7 @@ function validateClientOpts(opts) {
     throw new Error('Default TTL cannot be less than or equal to zero');
   }
 
+  opts.cacheClient = Promise.promisifyAll(opts.cacheClient);
   return opts;
 }
 

--- a/lib/ceych.js
+++ b/lib/ceych.js
@@ -74,7 +74,7 @@ class Ceych {
   }
 
   wrap(func) {
-    const args = Array.prototype.slice.call(arguments);
+    const args = Array.from(arguments);
     const opts = getWrapOpts(this.defaultTTL, args);
     if (this.stats) {
       opts.statsClient = this.stats;

--- a/lib/ceych.js
+++ b/lib/ceych.js
@@ -4,17 +4,22 @@ const _ = require('lodash');
 const Catbox = require('catbox').Client;
 const Memory = require('catbox-memory');
 const memoize = require('./memoize');
+const Promise = require('bluebird');
+
+function buildDefaultCacheClient() {
+  return Promise.promisifyAll(new Catbox(new Memory()));
+}
 
 function validateClientOpts(opts) {
   if (!opts) {
     opts = {
-      cacheClient: new Catbox(new Memory()),
+      cacheClient: buildDefaultCacheClient(),
       defaultTTL: 30
     };
   }
 
   if (!opts.cacheClient) {
-    opts.cacheClient = new Catbox(new Memory());
+    opts.cacheClient = buildDefaultCacheClient();
   }
 
   if (!opts.hasOwnProperty('defaultTTL')) {
@@ -58,29 +63,28 @@ function getWrapOpts(defaultTTL, args) {
   };
 }
 
-function Ceych(opts) {
-  opts = validateClientOpts(opts);
+class Ceych {
+  constructor(opts) {
+    opts = validateClientOpts(opts);
+    opts.cacheClient.start(_.noop);
 
-  opts.cacheClient.start(_.noop);
-
-  this.defaultTTL = opts.defaultTTL;
-  this.cache = opts.cacheClient;
-  this.stats = opts.statsClient;
-}
-
-Ceych.prototype.wrap = function wrap(func, ttl, suffix) { // eslint-disable-line no-unused-vars
-  const args = Array.prototype.slice.call(arguments);
-  const opts = getWrapOpts(this.defaultTTL, args);
-
-  if (this.stats) {
-    opts.statsClient = this.stats;
+    this.defaultTTL = opts.defaultTTL;
+    this.cache = opts.cacheClient;
+    this.stats = opts.statsClient;
   }
 
-  return memoize(this.cache, opts, func);
-};
+  wrap(func) {
+    const args = Array.prototype.slice.call(arguments);
+    const opts = getWrapOpts(this.defaultTTL, args);
+    if (this.stats) {
+      opts.statsClient = this.stats;
+    }
+    return memoize(this.cache, opts, func);
+  }
 
-Ceych.prototype.disableCache = function() {
-  this.cache.stop();
-};
+  disableCache() {
+    this.cache.stop();
+  }
+}
 
 module.exports = Ceych;

--- a/lib/ceych.js
+++ b/lib/ceych.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const Catbox = require('catbox').Client;
 const Memory = require('catbox-memory');
 const memoize = require('./memoize');
-const Promise = require('bluebird');
+const promisifyAll = require('./promiseUtils').promisifyAll;
 
 function createDefaultCacheClient() {
   return new Catbox(new Memory());
@@ -30,7 +30,7 @@ function validateClientOpts(opts) {
     throw new Error('Default TTL cannot be less than or equal to zero');
   }
 
-  opts.cacheClient = Promise.promisifyAll(opts.cacheClient);
+  opts.cacheClient = promisifyAll(opts.cacheClient);
   return opts;
 }
 

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -13,6 +13,13 @@ function createKey(func, args, suffix) {
   return hash.create(keyString);
 }
 
+function createCacheKey(fn, args, suffix) {
+  return {
+    id: createKey(fn, args, suffix),
+    segment: `ceych_${packageVersion}`
+  };
+}
+
 function getFunctionCallback(args) {
   const cb = args[args.length - 1];
   if (typeof cb === 'function') {
@@ -44,24 +51,19 @@ module.exports = (cacheClient, cacheOpts, fn) => {
     const args = Array.from(arguments);
     const cb = getFunctionCallback(args);
 
-    let keyString;
+    let cacheKey;
     try {
-      keyString = createKey(fn, args, suffix);
+      cacheKey = createCacheKey(fn, args, suffix);
     } catch (e) {
       const err = new Error(`Failed to create cache key from arguments: ${e.message}`);
       return promiseUtils.asCallBack(Promise.reject(err), cb);
     }
 
-    const key = {
-      id: keyString,
-      segment: `ceych_${packageVersion}`
-    };
-
     if (!cacheClient.isReady()) {
-      return promiseUtils.asCallBack(Promise.resolve(), cb);
+      return promiseUtils.asCallBack(Promise.resolve(null), cb);
     }
 
-    const reply = cacheClient.getAsync(key)
+    const reply = cacheClient.getAsync(cacheKey)
       .catch((err) => Promise.reject(err))
       .then((cached) => {
         if (cached) {
@@ -73,7 +75,7 @@ module.exports = (cacheClient, cacheOpts, fn) => {
         if (cb) {
           fnWrapper = promiseUtils.promisify(fnWrapper);
         }
-        return fnWrapper.apply(null, args).then(setInCache(key, ttl));
+        return fnWrapper.apply(null, args).then(setInCache(cacheKey, ttl));
       });
 
     if (cb) {

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -14,7 +14,7 @@ function createKey(func, args, suffix) {
 }
 
 function getFunctionArgs(_args) {
-  const args = Array.prototype.slice.call(_args);
+  const args = Array.from(_args);
   if (!args.length) {
     throw new Error('Wrapped function must be passed a callback');
   }
@@ -29,7 +29,7 @@ function getFunctionCallback(args) {
   return callback;
 }
 
-module.exports = function (cacheClient, cacheOpts, func) {
+module.exports = (cacheClient, cacheOpts, func) => {
   return function () {
     const ttl = cacheOpts.ttl;
     const suffix = cacheOpts.suffix;

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -55,15 +55,15 @@ module.exports = (cacheClient, cacheOpts, func) => {
           return Promise.resolve(cached.item);
         }
         statsClient ? statsClient.increment('ceych.misses') : _.noop();
+        let wrapped = func;
         if (callback) {
-          func = Promise.promisify(func, {
+          wrapped = Promise.promisify(wrapped, {
             multiArgs: true
           });
         }
-        return func.apply(null, args)
+        return wrapped.apply(null, args)
           .then((returnValues) => {
-            const args = [null].concat(returnValues);
-            return cacheClient.setAsync(key, args, ttl * 1000).then(() => returnValues);
+            return cacheClient.setAsync(key, returnValues, ttl * 1000).then(() => returnValues);
           });
       });
 

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -13,20 +13,12 @@ function createKey(func, args, suffix) {
   return hash.create(keyString);
 }
 
-function getFunctionArgs(_args) {
-  const args = Array.from(_args);
-  if (!args.length) {
-    throw new Error('Wrapped function must be passed a callback');
-  }
-  return args;
-}
-
 function getFunctionCallback(args) {
-  const callback = args.pop();
-  if (typeof callback !== 'function') {
-    throw new Error('Final argument of wrapped function must be a callback');
+  const cb = args[args.length - 1];
+  if (typeof cb === 'function') {
+    return args.pop();
   }
-  return callback;
+  return;
 }
 
 module.exports = (cacheClient, cacheOpts, func) => {
@@ -34,14 +26,15 @@ module.exports = (cacheClient, cacheOpts, func) => {
     const ttl = cacheOpts.ttl;
     const suffix = cacheOpts.suffix;
     const statsClient = cacheOpts.statsClient;
-    const args = getFunctionArgs(arguments);
+    const args = Array.from(arguments);
     const callback = getFunctionCallback(args);
 
     let keyString;
     try {
       keyString = createKey(func, args, suffix);
     } catch (e) {
-      return Promise.reject(new Error(`Failed to create cache key from arguments: ${e.message}`))
+      return Promise
+        .reject(new Error(`Failed to create cache key from arguments: ${e.message}`))
         .asCallback(callback);
     }
 
@@ -54,7 +47,7 @@ module.exports = (cacheClient, cacheOpts, func) => {
       return Promise.resolve().asCallback(callback);
     }
 
-    return cacheClient.getAsync(key)
+    const reply = cacheClient.getAsync(key)
       .catch((err) => Promise.reject(err))
       .then((cached) => {
         if (cached) {
@@ -72,9 +65,14 @@ module.exports = (cacheClient, cacheOpts, func) => {
             const args = [null].concat(returnValues);
             return cacheClient.setAsync(key, args, ttl * 1000).then(() => returnValues);
           });
-      }).asCallback((err, args) => {
+      });
+
+    if (callback) {
+      reply.asCallback((err, args) => {
         if (err) return callback(err);
         callback.apply(null, [null].concat(args));
       });
+    }
+    return reply;
   };
 };

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -1,42 +1,36 @@
 'use strict';
 
 const _ = require('lodash');
-const async = require('async');
 const hash = require('./hash');
 const packageVersion = require('../package').version;
+const Promise = require('bluebird');
 
 function createKey(func, args, suffix) {
   let keyString = func.toString().concat(JSON.stringify(args));
-
   if (suffix.length) {
     keyString += suffix;
   }
-
   return hash.create(keyString);
 }
 
 function getFunctionArgs(_args) {
   const args = Array.prototype.slice.call(_args);
-
   if (!args.length) {
     throw new Error('Wrapped function must be passed a callback');
   }
-
   return args;
 }
 
 function getFunctionCallback(args) {
   const callback = args.pop();
-
   if (typeof callback !== 'function') {
     throw new Error('Final argument of wrapped function must be a callback');
   }
-
   return callback;
 }
 
-module.exports = function(cacheClient, cacheOpts, func) {
-  return function() {
+module.exports = function (cacheClient, cacheOpts, func) {
+  return function () {
     const ttl = cacheOpts.ttl;
     const suffix = cacheOpts.suffix;
     const statsClient = cacheOpts.statsClient;
@@ -44,11 +38,11 @@ module.exports = function(cacheClient, cacheOpts, func) {
     const callback = getFunctionCallback(args);
 
     let keyString;
-
     try {
       keyString = createKey(func, args, suffix);
     } catch (e) {
-      return callback(new Error(`Failed to create cache key from arguments: ${e.message}`));
+      return Promise.reject(new Error(`Failed to create cache key from arguments: ${e.message}`))
+        .asCallback(callback);
     }
 
     const key = {
@@ -56,46 +50,31 @@ module.exports = function(cacheClient, cacheOpts, func) {
       segment: `ceych_${packageVersion}`
     };
 
-    async.waterfall([
-      function getFromCache(done) {
-        if (!cacheClient.isReady()) {
-          return done(null, null);
+    if (!cacheClient.isReady()) {
+      return Promise.resolve().asCallback(callback);
+    }
+
+    return cacheClient.getAsync(key)
+      .catch((err) => Promise.reject(err))
+      .then((cached) => {
+        if (cached) {
+          statsClient ? statsClient.increment('ceych.hits') : _.noop();
+          return Promise.resolve(cached.item);
         }
-
-        cacheClient.get(key, (err, cached) => {
-          if (err) return done(err);
-
-          if (cached) {
-            statsClient ? statsClient.increment('ceych.hits') : _.noop();
-            return done(null, cached);
-          }
-
-          statsClient ? statsClient.increment('ceych.misses') : _.noop();
-
-          done(null, null);
-        });
-      },
-      function applyFunction(cached, done) {
-        if (cached) return done(null, cached.item, false);
-
-        func.apply(null, args.concat(function() {
-          const returnValues = Array.prototype.slice.call(arguments);
-          const err = returnValues[0];
-
-          if (err) return done(err);
-
-          done(null, returnValues, true);
-        }));
-      },
-      function setInCache(returnValues, setInCache, done) {
-        if (!cacheClient.isReady() || !setInCache) return done.apply(null, returnValues);
-
-        cacheClient.set(key, returnValues, ttl * 1000, (err) => {
-          if (err) return done(err);
-
-          done.apply(null, returnValues);
-        });
-      }
-    ], callback);
+        statsClient ? statsClient.increment('ceych.misses') : _.noop();
+        if (callback) {
+          func = Promise.promisify(func, {
+            multiArgs: true
+          });
+        }
+        return func.apply(null, args)
+          .then((returnValues) => {
+            const args = [null].concat(returnValues);
+            return cacheClient.setAsync(key, args, ttl * 1000).then(() => returnValues);
+          });
+      }).asCallback((err, args) => {
+        if (err) return callback(err);
+        callback.apply(null, [null].concat(args));
+      });
   };
 };

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -51,16 +51,16 @@ module.exports = (cacheClient, cacheOpts, fn) => {
     const args = Array.from(arguments);
     const cb = getFunctionCallback(args);
 
+    if (!cacheClient.isReady()) {
+      return promiseUtils.asCallBack(Promise.resolve(null), cb);
+    }
+
     let cacheKey;
     try {
       cacheKey = createCacheKey(fn, args, suffix);
     } catch (e) {
       const err = new Error(`Failed to create cache key from arguments: ${e.message}`);
       return promiseUtils.asCallBack(Promise.reject(err), cb);
-    }
-
-    if (!cacheClient.isReady()) {
-      return promiseUtils.asCallBack(Promise.resolve(null), cb);
     }
 
     const reply = cacheClient.getAsync(cacheKey)

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const hash = require('./hash');
 const packageVersion = require('../package').version;
-const Promise = require('bluebird');
+const promiseUtils = require('./promiseUtils');
 
 function createKey(func, args, suffix) {
   let keyString = func.toString().concat(JSON.stringify(args));
@@ -22,27 +22,34 @@ function getFunctionCallback(args) {
 }
 
 function registerCallback(promise, cb) {
-  promise.asCallback((err, args) => {
+  promiseUtils.asCallBack(promise, (err, args) => {
     if (err) return cb(err);
     cb.apply(null, [null].concat(args));
   });
 }
 
-module.exports = (cacheClient, cacheOpts, func) => {
+module.exports = (cacheClient, cacheOpts, fn) => {
+  function setInCache(key, ttl) {
+    return (returnValues) => {
+      return cacheClient
+        .setAsync(key, returnValues, ttl * 1000)
+        .then(() => returnValues);
+    };
+  }
+
   return function () {
     const ttl = cacheOpts.ttl;
     const suffix = cacheOpts.suffix;
     const statsClient = cacheOpts.statsClient;
     const args = Array.from(arguments);
-    const callback = getFunctionCallback(args);
+    const cb = getFunctionCallback(args);
 
     let keyString;
     try {
-      keyString = createKey(func, args, suffix);
+      keyString = createKey(fn, args, suffix);
     } catch (e) {
-      return Promise
-        .reject(new Error(`Failed to create cache key from arguments: ${e.message}`))
-        .asCallback(callback);
+      const err = new Error(`Failed to create cache key from arguments: ${e.message}`);
+      return promiseUtils.asCallBack(Promise.reject(err), cb);
     }
 
     const key = {
@@ -51,7 +58,7 @@ module.exports = (cacheClient, cacheOpts, func) => {
     };
 
     if (!cacheClient.isReady()) {
-      return Promise.resolve().asCallback(callback);
+      return promiseUtils.asCallBack(Promise.resolve(), cb);
     }
 
     const reply = cacheClient.getAsync(key)
@@ -62,20 +69,15 @@ module.exports = (cacheClient, cacheOpts, func) => {
           return Promise.resolve(cached.item);
         }
         statsClient ? statsClient.increment('ceych.misses') : _.noop();
-        let wrapped = func;
-        if (callback) {
-          wrapped = Promise.promisify(wrapped, {
-            multiArgs: true
-          });
+        let fnWrapper = fn;
+        if (cb) {
+          fnWrapper = promiseUtils.promisify(fnWrapper);
         }
-        return wrapped.apply(null, args)
-          .then((returnValues) => {
-            return cacheClient.setAsync(key, returnValues, ttl * 1000).then(() => returnValues);
-          });
+        return fnWrapper.apply(null, args).then(setInCache(key, ttl));
       });
 
-    if (callback) {
-      registerCallback(reply, callback);
+    if (cb) {
+      registerCallback(reply, cb);
     }
     return reply;
   };

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -21,6 +21,13 @@ function getFunctionCallback(args) {
   return;
 }
 
+function registerCallback(promise, cb) {
+  promise.asCallback((err, args) => {
+    if (err) return cb(err);
+    cb.apply(null, [null].concat(args));
+  });
+}
+
 module.exports = (cacheClient, cacheOpts, func) => {
   return function () {
     const ttl = cacheOpts.ttl;
@@ -68,10 +75,7 @@ module.exports = (cacheClient, cacheOpts, func) => {
       });
 
     if (callback) {
-      reply.asCallback((err, args) => {
-        if (err) return callback(err);
-        callback.apply(null, [null].concat(args));
-      });
+      registerCallback(reply, callback);
     }
     return reply;
   };

--- a/lib/promiseUtils.js
+++ b/lib/promiseUtils.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const bluebird = require('bluebird');
+
+module.exports.promisify = (fn) => {
+    return bluebird.promisify(fn, {
+        multiArgs: true
+    });
+};
+
+module.exports.asCallBack = (promise, cb) => {
+    return bluebird.resolve(promise).asCallback(cb);
+};

--- a/lib/promiseUtils.js
+++ b/lib/promiseUtils.js
@@ -8,6 +8,10 @@ module.exports.promisify = (fn) => {
     });
 };
 
+module.exports.promisifyAll = (obj) => {
+    return bluebird.promisifyAll(obj);
+};
+
 module.exports.asCallBack = (promise, cb) => {
     return bluebird.resolve(promise).asCallback(cb);
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "function",
     "ceych",
     "wrapper",
-    "promise"
+    "promise",
+    "memoize"
   ],
   "devDependencies": {
     "chai": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
+    "bluebird": "^3.5.0",
     "catbox": "^7.1.0",
     "catbox-memory": "^2.0.1",
-    "lodash": "^4.3.0",
-    "async": "^1.5.0"
+    "lodash": "^4.3.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ceych",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Wraps any asynchronous function and provides caching of the result",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,15 @@
     "type": "git",
     "url": "git+ssh://git@github.com/bbc/ceych.git"
   },
+  "keywords": [
+    "cache",
+    "caching",
+    "asynchronous",
+    "function",
+    "ceych",
+    "wrapper",
+    "promise"
+  ],
   "devDependencies": {
     "chai": "^3.4.1",
     "eslint": "^1.10.3",

--- a/test/lib/ceych.js
+++ b/test/lib/ceych.js
@@ -4,7 +4,7 @@ const assert = require('chai').assert;
 const Catbox = require('catbox').Client;
 const sinon = require('sinon');
 const Memory = require('catbox-memory');
-const Promise = require('bluebird');
+const promisifyAll = require('../../lib/promiseUtils').promisifyAll;
 
 const hash = require('../../lib/hash');
 const Ceych = require('../../lib/ceych');
@@ -14,7 +14,7 @@ const sandbox = sinon.sandbox.create();
 describe('ceych', () => {
   let ceych;
   const wrappable = sandbox.stub().returns(Promise.resolve(1));
-  const cacheClient = Promise.promisifyAll(new Catbox(new Memory()));
+  const cacheClient = promisifyAll(new Catbox(new Memory()));
   const wrappableWithCb = sandbox.stub().yields(null, 1);
 
   beforeEach(() => {

--- a/test/lib/ceych.js
+++ b/test/lib/ceych.js
@@ -13,13 +13,12 @@ const sandbox = sinon.sandbox.create();
 
 describe('ceych', () => {
   let ceych;
-  let wrappable;
-  let cacheClient;
+  const wrappable = sandbox.stub().returns(Promise.resolve(1));
+  const cacheClient = Promise.promisifyAll(new Catbox(new Memory()));
+  const wrappableWithCb = sandbox.stub().yields(null, 1);
 
   beforeEach(() => {
     sandbox.stub(hash, 'create').returns('hashed');
-    cacheClient = Promise.promisifyAll(new Catbox(new Memory()));
-    wrappable = sandbox.stub().yields(null, 1);
 
     ceych = new Ceych({
       cacheClient: cacheClient
@@ -81,41 +80,55 @@ describe('ceych', () => {
         }, Error, 'Can only wrap a function, received [1]');
       });
 
-      it('sets the TTL if the second argument is an integer', (done) => {
+      it('sets the TTL if the second argument is an integer', () => {
         sandbox.stub(cacheClient, 'setAsync').returns(Promise.resolve());
         sandbox.stub(cacheClient, 'isReady').returns(true);
 
         const func = ceych.wrap(wrappable, 5);
 
-        func((err) => {
-          assert.ifError(err);
-          sinon.assert.calledWith(cacheClient.setAsync, sinon.match.any, sinon.match.any, 5000);
-          done();
-        });
+        return func()
+          .catch(assert.ifError)
+          .then(() => {
+            sinon.assert.calledWith(cacheClient.setAsync, sinon.match.any, sinon.match.any, 5000);
+          });
       });
 
-      it('sets the suffix if the third argument is a string', (done) => {
+      it('sets the suffix if the third argument is a string', () => {
         sandbox.stub(cacheClient, 'setAsync').returns(Promise.resolve());
         const func = ceych.wrap(wrappable, 5, 'suffix');
 
-        func((err) => {
-          assert.ifError(err);
-          sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
-            id: 'hashed'
-          }));
-          done();
-        });
+        return func()
+          .catch(assert.ifError)
+          .then(() => {
+            sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
+              id: 'hashed'
+            }));
+          });
       });
 
-      it('uses the defaultTTL if the suffix is passed in as the second argument', (done) => {
+      it('uses the defaultTTL if the suffix is passed in as the second argument', () => {
         sandbox.stub(cacheClient, 'setAsync').returns(Promise.resolve());
         const func = ceych.wrap(wrappable, 'suffix');
 
-        func((err) => {
+        func()
+          .catch(assert.ifError)
+          .then(() => {
+            sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
+              id: 'hashed'
+            }), sinon.match.any, 30000);
+          });
+      });
+
+      it('supports callbacks', (done) => {
+        const cachedValue = Promise.resolve({
+          item: 1
+        });
+        sandbox.stub(cacheClient, 'getAsync').returns(cachedValue);
+        const func = ceych.wrap(wrappableWithCb);
+
+        func((err, result) => {
           assert.ifError(err);
-          sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
-            id: 'hashed'
-          }), sinon.match.any, 30000);
+          assert.equal(result, 1);
           done();
         });
       });
@@ -130,7 +143,7 @@ describe('ceych', () => {
           statsClient: statsClient
         });
 
-        const func = ceychWithStats.wrap(wrappable);
+        const func = ceychWithStats.wrap(wrappableWithCb);
 
         func((err) => {
           assert.ifError(err);

--- a/test/lib/ceych.js
+++ b/test/lib/ceych.js
@@ -1,13 +1,15 @@
 'use strict';
 
 const assert = require('chai').assert;
-const hash = require('../../lib/hash');
 const Catbox = require('catbox').Client;
 const sinon = require('sinon');
-const sandbox = sinon.sandbox.create();
 const Memory = require('catbox-memory');
+const Promise = require('bluebird');
 
+const hash = require('../../lib/hash');
 const Ceych = require('../../lib/ceych');
+
+const sandbox = sinon.sandbox.create();
 
 describe('ceych', () => {
   let ceych;
@@ -16,7 +18,7 @@ describe('ceych', () => {
 
   beforeEach(() => {
     sandbox.stub(hash, 'create').returns('hashed');
-    cacheClient = new Catbox(new Memory());
+    cacheClient = Promise.promisifyAll(new Catbox(new Memory()));
     wrappable = sandbox.stub().yields(null, 1);
 
     ceych = new Ceych({
@@ -80,25 +82,25 @@ describe('ceych', () => {
       });
 
       it('sets the TTL if the second argument is an integer', (done) => {
-        sandbox.stub(cacheClient, 'set').yields();
+        sandbox.stub(cacheClient, 'setAsync').returns(Promise.resolve());
         sandbox.stub(cacheClient, 'isReady').returns(true);
 
         const func = ceych.wrap(wrappable, 5);
 
         func((err) => {
           assert.ifError(err);
-          sinon.assert.calledWith(cacheClient.set, sinon.match.any, sinon.match.any, 5000);
+          sinon.assert.calledWith(cacheClient.setAsync, sinon.match.any, sinon.match.any, 5000);
           done();
         });
       });
 
       it('sets the suffix if the third argument is a string', (done) => {
-        sandbox.stub(cacheClient, 'set').yields();
+        sandbox.stub(cacheClient, 'setAsync').returns(Promise.resolve());
         const func = ceych.wrap(wrappable, 5, 'suffix');
 
         func((err) => {
           assert.ifError(err);
-          sinon.assert.calledWith(cacheClient.set, sinon.match({
+          sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
             id: 'hashed'
           }));
           done();
@@ -106,12 +108,12 @@ describe('ceych', () => {
       });
 
       it('uses the defaultTTL if the suffix is passed in as the second argument', (done) => {
-        sandbox.stub(cacheClient, 'set').yields();
+        sandbox.stub(cacheClient, 'setAsync').returns(Promise.resolve());
         const func = ceych.wrap(wrappable, 'suffix');
 
         func((err) => {
           assert.ifError(err);
-          sinon.assert.calledWith(cacheClient.set, sinon.match({
+          sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
             id: 'hashed'
           }), sinon.match.any, 30000);
           done();

--- a/test/lib/memoize.js
+++ b/test/lib/memoize.js
@@ -284,7 +284,7 @@ describe('memoize', () => {
           .then(() => {
             sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
               id: 'hashed'
-            }), [null, 1]);
+            }), 1);
           });
       });
 
@@ -296,7 +296,7 @@ describe('memoize', () => {
           assert.ifError(err);
           sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
             id: 'hashed'
-          }), [null, 1]);
+          }), [1]);
           done();
         });
       });
@@ -309,7 +309,7 @@ describe('memoize', () => {
           .then(() => {
             sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
               id: 'hashed'
-            }), [null, null]);
+            }), null);
           });
       });
 
@@ -325,7 +325,7 @@ describe('memoize', () => {
           .then(() => {
             sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
               id: 'hashed'
-            }), [null, 1], 10000);
+            }), 1, 10000);
           });
       });
 
@@ -338,7 +338,7 @@ describe('memoize', () => {
           .then(() => {
             sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
               segment: `ceych_${packageVersion}`
-            }), [null, 1]);
+            }), 1);
           });
       });
 

--- a/test/lib/memoize.js
+++ b/test/lib/memoize.js
@@ -19,7 +19,7 @@ function Circular() {
   this.circular = this;
 }
 
-describe.only('memoize', () => {
+describe('memoize', () => {
   let cacheClient;
 
   beforeEach(() => {

--- a/test/lib/memoize.js
+++ b/test/lib/memoize.js
@@ -9,7 +9,11 @@ const hash = require('../../lib/hash');
 const memoize = require('../../lib/memoize');
 const packageVersion = require('../../package.json').version;
 
-const wrappable = (cb) => cb(null, 1);
+const wrappableWithCb = (cb) => cb(null, 1);
+const wrappable = () => {
+  return Promise.resolve(1);
+};
+
 const opts = {
   ttl: 30,
   suffix: ''
@@ -36,64 +40,64 @@ describe('memoize', () => {
   });
 
   describe('hashing', () => {
-    it('hashes the function as a string when there are no arguments', (done) => {
+    it('hashes the function as a string when there are no arguments', () => {
       const func = memoize(cacheClient, opts, wrappable);
 
-      func((err) => {
-        assert.ifError(err);
-        sinon.assert.calledWith(hash.create, `${wrappable.toString()}[]`);
-        done();
-      });
+      func()
+        .catch(assert.ifError)
+        .then(() => {
+          sinon.assert.calledWith(hash.create, `${wrappable.toString()}[]`);
+        });
     });
 
-    it('hashes the function as a string along with its arguments', (done) => {
-      const wrappableMultipleArgs = (one, two, three, four, cb) => {
-        return cb(null, 1);
+    it('hashes the function as a string along with its arguments', () => {
+      const wrappableMultipleArgs = (one, two, three, four) => {
+        return Promise.resolve(four - three - two - one + three);
       };
       const func = memoize(cacheClient, opts, wrappableMultipleArgs);
 
-      func(1, 2, 3, 4, (err) => {
-        assert.ifError(err);
-        sinon.assert.calledWith(hash.create, `${wrappableMultipleArgs.toString()}[1,2,3,4]`);
-        done();
-      });
+      return func(1, 2, 3, 4)
+        .catch(assert.ifError)
+        .then(() => {
+          sinon.assert.calledWith(hash.create, `${wrappableMultipleArgs.toString()}[1,2,3,4]`);
+        });
     });
 
-    it('hashes the function as a string along with its arguments and a suffix', (done) => {
+    it('hashes the function as a string along with its arguments and a suffix', () => {
       const differentOpts = _.cloneDeep(opts);
       differentOpts.suffix = 'some differentiating suffix';
 
-      const wrappableMultipleArgs = (one, two, three, four, cb) => {
-        return cb(null, 1);
+      const wrappableMultipleArgs = (one, two, three, four) => {
+        return Promise.resolve(four - three - two - one + three);
       };
       const func = memoize(cacheClient, differentOpts, wrappableMultipleArgs);
 
-      func(1, 2, 3, 4, (err) => {
-        assert.ifError(err);
-        sinon.assert.calledWith(hash.create, `${wrappableMultipleArgs.toString()}[1,2,3,4]some differentiating suffix`);
-        done();
-      });
+      func(1, 2, 3, 4)
+        .catch(assert.ifError)
+        .then(() => {
+          sinon.assert.calledWith(hash.create, `${wrappableMultipleArgs.toString()}[1,2,3,4]${differentOpts.suffix}`);
+        });
     });
 
-    it('stringifies objects before hashing', (done) => {
-      const wrappableWithObject = (obj, cb) => {
-        return cb(null, obj);
+    it('stringifies objects before hashing', () => {
+      const wrappableWithObject = (obj) => {
+        return Promise.resolve(obj);
       };
       const func = memoize(cacheClient, opts, wrappableWithObject);
 
-      func({
-        testing: '123'
-      }, (err) => {
-        assert.ifError(err);
-        sinon.assert.calledWith(hash.create, `${wrappableWithObject.toString()}[{"testing":"123"}]`);
-        done();
-      });
+      return func({
+          testing: '123'
+        })
+        .catch(assert.ifError)
+        .then(() => {
+          sinon.assert.calledWith(hash.create, `${wrappableWithObject.toString()}[{"testing":"123"}]`);
+        });
     });
   });
 
   describe('caching', () => {
     describe('retrieving from cache', () => {
-      it('returns the result from the cache if one exists', (done) => {
+      it('returns the result from the cache if one exists', () => {
         const cachedValue = Promise.resolve({
           item: 1
         });
@@ -103,14 +107,14 @@ describe('memoize', () => {
 
         const func = memoize(cacheClient, opts, wrappable);
 
-        func((err, results) => {
-          assert.ifError(err);
-          assert.strictEqual(results, 1);
-          done();
-        });
+        func()
+          .catch(assert.ifError)
+          .then((results) => {
+            assert.strictEqual(results, 1);
+          });
       });
 
-      it('does not call the wrapped function if there is a result in the cache', (done) => {
+      it('does not call the wrapped function if there is a result in the cache', () => {
         cacheClient.getAsync.withArgs(sinon.match({
           id: 'hashed'
         })).returns(Promise.resolve({
@@ -120,14 +124,14 @@ describe('memoize', () => {
         const wrappableStub = sandbox.stub().returns(Promise.resolve(1));
         const func = memoize(cacheClient, opts, wrappableStub);
 
-        func((err) => {
-          assert.ifError(err);
-          sinon.assert.notCalled(wrappableStub);
-          done();
-        });
+        return func()
+          .catch(assert.ifError)
+          .then(() => {
+            sinon.assert.notCalled(wrappableStub);
+          });
       });
 
-      it('returns a null value if it exists in the cache', (done) => {
+      it('returns a null value if it exists in the cache', () => {
         cacheClient.getAsync.withArgs(sinon.match({
           id: 'hashed'
         })).returns(Promise.resolve({
@@ -137,90 +141,91 @@ describe('memoize', () => {
         const wrappableStub = sandbox.stub().returns();
         const func = memoize(cacheClient, opts, wrappableStub);
 
-        func((err, results) => {
-          assert.ifError(err);
-          sinon.assert.notCalled(wrappableStub);
-          assert.strictEqual(results, null);
-          done();
-        });
+        return func()
+          .catch(assert.ifError)
+          .then((results) => {
+            sinon.assert.notCalled(wrappableStub);
+            assert.strictEqual(results, null);
+          });
       });
 
-      it('does not attempt to retrieve from the cache if the cache is not ready', (done) => {
+      it('does not attempt to retrieve from the cache if the cache is not ready', () => {
         cacheClient.isReady.returns(false);
 
         const wrappableStub = sandbox.stub().returns();
         const func = memoize(cacheClient, opts, wrappableStub);
 
-        func((err) => {
-          assert.ifError(err);
-          sinon.assert.notCalled(cacheClient.getAsync);
-          done();
-        });
+        return func()
+          .catch(assert.ifError)
+          .then(() => {
+            sinon.assert.notCalled(cacheClient.getAsync);
+          });
       });
 
-      it('returns an error to the callback if retrieving from the cache fails', (done) => {
-        const func = memoize(cacheClient, opts, wrappable);
+      it('returns an error to the callback if retrieving from the cache fails', () => {
+        const func = memoize(cacheClient, opts, wrappableWithCb);
         cacheClient.getAsync.returns(Promise.reject(new Error('GET Error!')));
 
-        func((err) => {
-          assert.ok(err);
-          assert.strictEqual(err.message, 'GET Error!');
-          done();
-        });
+        return func()
+          .then(() => {
+            assert.fail('Expected error to be returned!');
+          })
+          .catch((err) => {
+            assert.strictEqual(err.message, 'GET Error!');
+          });
       });
     });
 
     describe('calling wrapped function', () => {
-      it('calls the wrapped function when the cache does not return anything', (done) => {
-        const wrappableStub = sandbox.stub().yields(null, 1);
+      it('calls the wrapped function when the cache does not return anything', () => {
+        const wrappableStub = sandbox.stub().returns(Promise.resolve(1));
         const func = memoize(cacheClient, opts, wrappableStub);
 
-        func((err, results) => {
-          assert.ifError(err);
-          sinon.assert.called(wrappableStub);
-          assert.strictEqual(results, 1);
-          done();
-        });
+        return func()
+          .catch(assert.ifError)
+          .then((results) => {
+            sinon.assert.called(wrappableStub);
+            assert.strictEqual(results, 1);
+          });
       });
 
-      it('calls the wrapped function with its arguments when the cache does not return anything', (done) => {
-        const wrappableStub = sandbox.stub().yields(null, 1);
+      it('calls the wrapped function with its arguments when the cache does not return anything', () => {
+        const wrappableStub = sandbox.stub().returns(Promise.resolve(1));
         const func = memoize(cacheClient, opts, wrappableStub);
 
-        func(1, {
-          two: 'three'
-        }, [4], 'five', (err) => {
-          assert.ifError(err);
-          sinon.assert.calledWith(wrappableStub, 1, sinon.match({
+        return func(1, {
             two: 'three'
-          }), [4], 'five', sinon.match.func);
-          done();
-        });
+          }, [4], 'five')
+          .catch(assert.ifError)
+          .then(() => {
+            sinon.assert.calledWith(wrappableStub, 1, sinon.match({
+              two: 'three'
+            }), [4], 'five');
+          });
       });
 
-      it('supports multiple return values', (done) => {
-        const wrappableStub = sandbox.stub().yields(null, 1, 2, 3);
+      it('supports multiple return values', () => {
+        const wrappableStub = sandbox.stub().returns(Promise.resolve([1, 2, 3]));
         const func = memoize(cacheClient, opts, wrappableStub);
 
-        func((err, resultOne, resultTwo, resultThree) => {
-          assert.ifError(err);
-          assert.equal(resultOne, 1);
-          assert.equal(resultTwo, 2);
-          assert.equal(resultThree, 3);
-          done();
-        });
+        func()
+          .catch(assert.ifError)
+          .then((results) => {
+            assert.equal(results[0], 1);
+            assert.equal(results[1], 2);
+            assert.equal(results[2], 3);
+          });
       });
 
-      it('returns an error to the callback if the wrapped function throws an error', (done) => {
-        const wrappableStub = sandbox.stub().yields(new Error('Function Error!'));
+      it('returns an error to the callback if the wrapped function throws an error', () => {
+        const wrappableStub = sandbox.stub().returns(Promise.reject(new Error('Function Error!')));
         const func = memoize(cacheClient, opts, wrappableStub);
 
-        func((err) => {
-          assert.ok(err);
-          sinon.assert.called(wrappableStub);
-          assert.strictEqual(err.message, 'Function Error!');
-          done();
-        });
+        return func()
+          .catch((err) => {
+            sinon.assert.called(wrappableStub);
+            assert.strictEqual(err.message, 'Function Error!');
+          });
       });
     });
 
@@ -229,108 +234,93 @@ describe('memoize', () => {
         cacheClient.getAsync.returns(Promise.resolve(null, null));
       });
 
-      it('sets the results of the function in the cache', (done) => {
-        const wrappableStub = sandbox.stub().yields(null, 1);
+      it('sets the results of the function in the cache', () => {
+        const wrappableStub = sandbox.stub().returns(Promise.resolve(1));
         const func = memoize(cacheClient, opts, wrappableStub);
 
-        func((err) => {
-          assert.ifError(err);
-          sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
-            id: 'hashed'
-          }), [null, 1]);
-          done();
-        });
+        return func()
+          .catch(assert.ifError)
+          .then(() => {
+            sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
+              id: 'hashed'
+            }), [null, 1]);
+          });
       });
 
-      it('sets a return value of null to the cache', (done) => {
-        const wrappableStub = sandbox.stub().yields(null, null);
+      it('sets a return value of null to the cache', () => {
+        const wrappableStub = sandbox.stub().returns(Promise.resolve(null));
         const func = memoize(cacheClient, opts, wrappableStub);
 
-        func((err) => {
-          assert.ifError(err);
-          sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
-            id: 'hashed'
-          }), [null, null]);
-          done();
-        });
+        return func()
+          .then(() => {
+            sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
+              id: 'hashed'
+            }), [null, null]);
+          });
       });
 
-      it('sets the TTL as the expiry in milliseconds', (done) => {
+      it('sets the TTL as the expiry in milliseconds', () => {
         const differentOpts = _.cloneDeep(opts);
         differentOpts.ttl = 10;
 
-        const wrappableStub = sandbox.stub().yields(null, 1);
+        const wrappableStub = sandbox.stub().returns(Promise.resolve(1));
         const func = memoize(cacheClient, differentOpts, wrappableStub);
 
-        func((err) => {
-          assert.ifError(err);
-          sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
-            id: 'hashed'
-          }), [null, 1], 10000);
-          done();
-        });
+        return func()
+          .catch(assert.ifError)
+          .then(() => {
+            sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
+              id: 'hashed'
+            }), [null, 1], 10000);
+          });
       });
 
-      it('includes the package version in the key object', (done) => {
-        const wrappableStub = sandbox.stub().yields(null, 1);
+      it('includes the package version in the key object', () => {
+        const wrappableStub = sandbox.stub().returns(Promise.resolve(1));
         const func = memoize(cacheClient, opts, wrappableStub);
 
-        func((err) => {
-          assert.ifError(err);
-          sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
-            segment: `ceych_${packageVersion}`
-          }), [null, 1]);
-          done();
-        });
+        return func()
+          .catch(assert.ifError)
+          .then(() => {
+            sinon.assert.calledWith(cacheClient.setAsync, sinon.match({
+              segment: `ceych_${packageVersion}`
+            }), [null, 1]);
+          });
       });
 
-      it('does not attempt to set to the cache if the cache is not ready', (done) => {
+      it('does not attempt to set to the cache if the cache is not ready', () => {
         cacheClient.isReady.returns(false);
 
-        const wrappableStub = sandbox.stub().yields(null, 1);
+        const wrappableStub = sandbox.stub().returns(Promise.resolve(1));
         const func = memoize(cacheClient, opts, wrappableStub);
 
-        func((err) => {
-          assert.ifError(err);
-          sinon.assert.notCalled(cacheClient.setAsync);
-          done();
-        });
+        return func()
+          .catch(assert.ifError)
+          .then(() => {
+            sinon.assert.notCalled(cacheClient.setAsync);
+          });
       });
 
-      it('returns an error to the callback if saving to the cache fails', (done) => {
+      it('returns an error to the callback if saving to the cache fails', () => {
         cacheClient.setAsync.returns(Promise.reject(new Error('SET Error!')));
         const func = memoize(cacheClient, opts, wrappable);
 
-        func((err) => {
-          assert.ok(err);
-          assert.strictEqual(err.message, 'SET Error!');
-          done();
-        });
+        return func()
+          .catch((err) => {
+            assert.strictEqual(err.message, 'SET Error!');
+          });
       });
     });
   });
 
   describe('wrapped function parameters', () => {
-    it('returns an error when one of the arguments cannot be stringified', (done) => {
+    it('returns an error when one of the arguments cannot be stringified', () => {
       const func = memoize(cacheClient, opts, wrappable);
 
-      func(new Circular(), (err) => {
-        assert.ok(err);
-        assert.strictEqual(err.message, 'Failed to create cache key from arguments: Converting circular structure to JSON');
-        done();
-      });
-    });
-
-    it('throws an error if a callback is not passed as an argument', () => {
-      const func = memoize(cacheClient, opts, wrappable);
-      assert.throw(func, Error, 'Wrapped function must be passed a callback');
-    });
-
-    it('throws an error if the final argument is not a function', () => {
-      const func = memoize(cacheClient, opts, wrappable);
-      assert.throw(() => {
-        func(1, 2, 3);
-      }, Error, 'Final argument of wrapped function must be a callback');
+      func(new Circular())
+        .catch((err) => {
+          assert.strictEqual(err.message, 'Failed to create cache key from arguments: Converting circular structure to JSON');
+        });
     });
   });
 
@@ -348,7 +338,7 @@ describe('memoize', () => {
     });
 
     it('increments a StatsD counter every time there is a cache miss', (done) => {
-      const func = memoize(cacheClient, optsWithStats, wrappable);
+      const func = memoize(cacheClient, optsWithStats, wrappableWithCb);
 
       func((err) => {
         assert.ifError(err);
@@ -359,7 +349,7 @@ describe('memoize', () => {
 
     it('increments a StatsD counter every time there is a cache hit', (done) => {
       cacheClient.getAsync.returns(Promise.resolve([null, 1]));
-      const func = memoize(cacheClient, optsWithStats, wrappable);
+      const func = memoize(cacheClient, optsWithStats, wrappableWithCb);
 
       func((err) => {
         assert.ifError(err);

--- a/test/lib/memoize.js
+++ b/test/lib/memoize.js
@@ -4,7 +4,6 @@ const _ = require('lodash');
 const assert = require('chai').assert;
 const sinon = require('sinon');
 const sandbox = sinon.sandbox.create();
-const Promise = require('bluebird');
 const hash = require('../../lib/hash');
 const memoize = require('../../lib/memoize');
 const packageVersion = require('../../package.json').version;


### PR DESCRIPTION
Summary of changes:

- Switches from async.js to native node promise support
- util for promisifying callbacks. Uses bluebird (only used in util). Should be an easy to switch to use node 8 util at a future point. 

Future PR's
- Cache HIT/MISS events, decoupling statsD. #56
- doc updates, jsdocs and github pages. #57 