### PR TITLE
IPLAYER-46182: Add `enableCache()` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,8 @@ Returns a wrapped function that implements caching.
 
 #### `ceych.disableCache()`
 
-Disables the cache client to allow for wrapped methods to be tested as normal.
+Disables the use of the cache. This can be useful if you want to toggle usage of the cache for operational purposes - e.g. for operational purposes, or unit tests.
+
+#### `ceych.enableCache()`
+
+Re-enables the cache client. This can be useful if you want to toggle usage of the cache for operational purposes - e.g. for operational purposes, or unit tests.

--- a/lib/ceych.js
+++ b/lib/ceych.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const Catbox = require('@hapi/catbox').Client;
 const CatboxMemory = require('@hapi/catbox-memory');
 const memoize = require('./memoize');
@@ -20,7 +19,7 @@ function validateClientOpts(opts) {
   if (!opts.cacheClient) {
     opts.cacheClient = createDefaultCacheClient();
   }
-  
+
   if (!opts.hasOwnProperty('defaultTTL')) {  // eslint-disable-line no-prototype-builtins
     opts.defaultTTL = 30;
   }
@@ -65,7 +64,7 @@ function getWrapOpts(defaultTTL, args) {
 class Ceych {
   constructor(opts) {
     opts = validateClientOpts(opts);
-    opts.cacheClient.start(_.noop);
+    opts.cacheClient.start();
 
     this.defaultTTL = opts.defaultTTL;
     this.cache = opts.cacheClient;
@@ -82,7 +81,13 @@ class Ceych {
   }
 
   disableCache() {
-    this.cache.stop();
+    return this.cache.stop();
+  }
+
+  enableCache() {
+    if (!this.cache.isReady()) {
+      return this.cache.start();
+    }
   }
 }
 

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const hash = require('./hash');
 const packageVersion = require('../package').version;
 
@@ -32,7 +31,7 @@ module.exports = (cacheClient, cacheOpts, fn) => {
       await cacheClient.set(key, value, ttl * 1000);
       return value;
     } catch (err) {
-      statsClient ? statsClient.increment('ceych.errors') : _.noop();
+      statsClient ? statsClient.increment('ceych.errors') : () => {};
       throw err;
     }
   }
@@ -49,15 +48,15 @@ module.exports = (cacheClient, cacheOpts, fn) => {
     try {
       const reply = await cacheClient.get(cacheKey);
       if (reply) {
-        statsClient ? statsClient.increment('ceych.hits') : _.noop();
+        statsClient ? statsClient.increment('ceych.hits') : () => {};
         return reply.item;
       }
-      statsClient ? statsClient.increment('ceych.misses') : _.noop();
+      statsClient ? statsClient.increment('ceych.misses') : () => {};
       const results = await fn.apply(null, args);
       return await setInCache(cacheKey, results, ttl);
 
     } catch (err) {
-      statsClient ? statsClient.increment('ceych.errors') : _.noop();
+      statsClient ? statsClient.increment('ceych.errors') : () => {};
       throw err;
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/catbox": "^12.1.1",
-        "@hapi/catbox-memory": "^6.0.1",
-        "lodash": "^4.17.21"
+        "@hapi/catbox-memory": "^6.0.1"
       },
       "devDependencies": {
         "chai": "^4.3.7",
-        "eslint": "^8.36.0",
+        "eslint": "^8.38.0",
         "istanbul": "^0.4.5",
+        "lodash": "^4.17.21",
         "mocha": "^10.2.0",
-        "sinon": "^15.0.2"
+        "sinon": "^15.0.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1456,7 +1456,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -3420,7 +3421,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   },
   "dependencies": {
     "@hapi/catbox": "^12.1.1",
-    "@hapi/catbox-memory": "^6.0.1",
-    "lodash": "^4.17.21"
+    "@hapi/catbox-memory": "^6.0.1"
   },
   "repository": {
     "type": "git",
@@ -40,6 +39,7 @@
     "eslint": "^8.38.0",
     "istanbul": "^0.4.5",
     "mocha": "^10.2.0",
-    "sinon": "^15.0.3"
+    "sinon": "^15.0.3",
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
Also:
- Update code to reflect that Catbox.start() is async, but does not accept a parameter.
- Return result from disableCache(), to allow clients to await on the Promise.
- Lodash is now only a dev dependency.