### PR TITLE
Use performance.now() rather than new Date() for calculating timing metrics

### DIFF
--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -29,10 +29,10 @@ module.exports = (cacheClient, cacheOpts, fn) => {
   async function setInCache(key, value, ttl) {
     try {
       let startTime;
-      if (statsClient) startTime = new Date();
+      if (statsClient) startTime = performance.now();
 
       await cacheClient.set(key, value, ttl * 1000);
-      if (statsClient) statsClient.timing('ceych.write_time', new Date() - startTime);
+      if (statsClient) statsClient.timing('ceych.write_time', performance.now() - startTime);
       return value;
     } catch (err) {
       if (statsClient) statsClient.increment('ceych.errors');
@@ -51,10 +51,10 @@ module.exports = (cacheClient, cacheOpts, fn) => {
     const cacheKey = createCacheKey(fn, args, suffix);
     try {
       let startTime;
-      if (statsClient) startTime = new Date();
+      if (statsClient) startTime = performance.now();
 
       const reply = await cacheClient.get(cacheKey);
-      if (statsClient) statsClient.timing('ceych.read_time', new Date() - startTime);
+      if (statsClient) statsClient.timing('ceych.read_time', performance.now() - startTime);
 
       if (reply) {
         if (statsClient) statsClient.increment('ceych.hits');


### PR DESCRIPTION
Date objects only have millisecond precision, which results in timing values being rounded down by ~0.5 milliseconds on average. For in-memory caches and services like Redis, this can be significant.

performance.now() has microsecond precision, so rounding errors are reduced to ~0.5 microseconds on average.

Note that timing stats are reported in milliseconds, so this PR results in stats being reported as decimals rather than consistently as integers.